### PR TITLE
Fixes the .exe build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 							<jar>target/rodain-app-${project.version}.jar</jar>
 							<errTitle>Error opening RODA-in</errTitle>
 							<classPath>
-								<mainClass>org.roda.rodain.core.Main</mainClass>
+								<mainClass>org.roda.rodain.Main</mainClass>
 							</classPath>
 							<icon>src/main/resources/roda2-logo.ico</icon>
 							<jre>


### PR DESCRIPTION
The .exe doesn't open the app due to not finding the Main class. 

`Error: Could not find or load main class org.roda.rodain.core.Main`