### PR TITLE
Fixed the issue with InvalidPathException (Issue #322)

### DIFF
--- a/src/main/java/org/roda/rodain/core/rules/filters/ContentFilter.java
+++ b/src/main/java/org/roda/rodain/core/rules/filters/ContentFilter.java
@@ -94,11 +94,16 @@ public class ContentFilter {
         // slash we're checking
         if (index == -1) {
           break;
+        } else if (path.startsWith("\\\\")) {
+          //for UNC paths iterations throw the subs will bring an exception
+          return false;
         } else {
           String sub = path.substring(0, index);
           fromIndex = index + 1; // move the starting index for the next
           // iteration so it's after the slash
-          if (ignored.contains(sub) || mapped.contains(sub) || IgnoredFilter.isIgnored(Paths.get(sub))) {
+          if (ignored.contains(sub) || mapped.contains(sub)
+                  // Paths.get(sub) will rise InvalidPathException for UNC paths on some point of iteration
+                  || IgnoredFilter.isIgnored(Paths.get(sub))) {
             result = true;
           }
         }


### PR DESCRIPTION
Fixed the issue with InvalidPathException which broke associate proces for files with UNC path.

13:47:01 ERROR org.roda.rodain.ui.RodaInApplication - An unexpected error occurred in Thread[Thread-11,5,main]
java.nio.file.InvalidPathException: UNC path is missing sharename: \\vserver.ch
at sun.nio.fs.WindowsPathParser.parse(Unknown Source)
at sun.nio.fs.WindowsPathParser.parse(Unknown Source)
at sun.nio.fs.WindowsPath.parse(Unknown Source)
at sun.nio.fs.WindowsFileSystem.getPath(Unknown Source)
at java.nio.file.Paths.get(Unknown Source)
at org.roda.rodain.core.rules.filters.ContentFilter.filter(ContentFilter.java:101)
at org.roda.rodain.core.sip.creators.SipPreviewCreator.filter(SipPreviewCreator.java:152)
at org.roda.rodain.core.sip.creators.SipSingle.preVisitDirectory(SipSingle.java:56)
at org.roda.rodain.core.utils.WalkFileTree$1.preVisitDirectory(WalkFileTree.java:67)
at org.roda.rodain.core.utils.WalkFileTree$1.preVisitDirectory(WalkFileTree.java:57)
at java.nio.file.Files.walkFileTree(Unknown Source)
at java.nio.file.Files.walkFileTree(Unknown Source)
at org.roda.rodain.core.utils.WalkFileTree.run(WalkFileTree.java:57)